### PR TITLE
Fix error when maxLines is set, add auto option

### DIFF
--- a/src/exceptionFormatter.coffee
+++ b/src/exceptionFormatter.coffee
@@ -140,6 +140,12 @@ formatExceptionLines = (exception, options, lineFn) ->
     if options.maxLines and lines.length > options.maxLines
         lines = lines[0..options.maxLines]
         lines.push line: indent '[truncated]', type: DIVIDER
+    if options.maxLines is 'auto'
+        for line, i in lines by -1
+          if line.type is OUR_SOURCE
+            lines = lines[0..i]
+            lines.push line: indent '[truncated]', type: DIVIDER
+            break
 
     lines = lines.map lineFn
 

--- a/src/exceptionFormatter.coffee
+++ b/src/exceptionFormatter.coffee
@@ -135,10 +135,11 @@ parseException = do ->
 #
 formatExceptionLines = (exception, options, lineFn) ->
     lines = parseException exception, options
+    indent = (s) -> (lines[lines.length - 1].parsed?.indent or '') + s
 
     if options.maxLines and lines.length > options.maxLines
         lines = lines[0..options.maxLines]
-        lines.push lineFn("[truncated]", DIVIDER)
+        lines.push line: indent '[truncated]', type: DIVIDER
 
     lines = lines.map lineFn
 

--- a/test/exceptionFormatterTest.coffee
+++ b/test/exceptionFormatterTest.coffee
@@ -23,7 +23,7 @@ describe "exceptionFormatter", ->
               at ReadStream.Readable.push (_stream_readable.js:127:10)
               at TTY.onread (net.js:528:21)
         """
-        result = exceptionFormatter dummyException, {format: "ascii", basepath: '/Users/jwalton/project'}
+        result = exceptionFormatter dummyException, {format: "ascii", basepath: '/Users/jwalton/project/', basepathReplacement: './'}
         expect(result).to.equal """
             Error: foo
               at Interface.<anonymous> (/Users/jwalton/.nvm/v0.10.32/lib/node_modules/coffee-script/lib/coffee-script/repl.js:66:9)
@@ -42,7 +42,7 @@ describe "exceptionFormatter", ->
               at ReadStream.Readable.push (_stream_readable.js:127:10)
               at TTY.onread (net.js:528:21)
         """
-        result = exceptionFormatter dummyException, {format: "ascii", basepath: /\/Users\/jwalton\/project\//}
+        result = exceptionFormatter dummyException, {format: "ascii", basepath: /\/Users\/jwalton\/project\//, basepathReplacement: './'}
         expect(result).to.equal """
             Error: foo
               at Interface.<anonymous> (/Users/jwalton/.nvm/v0.10.32/lib/node_modules/coffee-script/lib/coffee-script/repl.js:66:9)
@@ -50,4 +50,21 @@ describe "exceptionFormatter", ->
             * at foo (./src/x/y.coffee:188:19)
               at ReadStream.Readable.push (_stream_readable.js:127:10)
               at TTY.onread (net.js:528:21)
+        """
+
+    it "should correctly limit number of lines", ->
+        dummyException = """
+            Error: foo
+              at Interface.<anonymous> (/Users/jwalton/.nvm/v0.10.32/lib/node_modules/coffee-script/lib/coffee-script/repl.js:66:9)
+              at bar (/Users/jwalton/project/node_modules/express/x/y.js:21:4)
+              at foo (/Users/jwalton/project/src/x/y.coffee:188:19)
+              at ReadStream.Readable.push (_stream_readable.js:127:10)
+              at TTY.onread (net.js:528:21)
+        """
+        result = exceptionFormatter dummyException, {format: "ascii", maxLines: 2, basepath: '/Users/jwalton/project/', basepathReplacement: './'}
+        expect(result).to.equal """
+            Error: foo
+              at Interface.<anonymous> (/Users/jwalton/.nvm/v0.10.32/lib/node_modules/coffee-script/lib/coffee-script/repl.js:66:9)
+              at bar (./node_modules/express/x/y.js:21:4)
+              [truncated]
         """

--- a/test/exceptionFormatterTest.coffee
+++ b/test/exceptionFormatterTest.coffee
@@ -68,3 +68,40 @@ describe "exceptionFormatter", ->
               at bar (./node_modules/express/x/y.js:21:4)
               [truncated]
         """
+
+    it "should automatically limit number of lines", ->
+        dummyException = """
+            Error: foo
+              at Interface.<anonymous> (/Users/jwalton/.nvm/v0.10.32/lib/node_modules/coffee-script/lib/coffee-script/repl.js:66:9)
+              at bar (/Users/jwalton/project/node_modules/express/x/y.js:21:4)
+              at foo (/Users/jwalton/project/src/x/y.coffee:188:19)
+              at ReadStream.Readable.push (_stream_readable.js:127:10)
+              at TTY.onread (net.js:528:21)
+        """
+        result = exceptionFormatter dummyException, {format: "ascii", maxLines: 'auto', basepath: '/Users/jwalton/project/', basepathReplacement: './'}
+        expect(result).to.equal """
+            Error: foo
+              at Interface.<anonymous> (/Users/jwalton/.nvm/v0.10.32/lib/node_modules/coffee-script/lib/coffee-script/repl.js:66:9)
+              at bar (./node_modules/express/x/y.js:21:4)
+            * at foo (./src/x/y.coffee:188:19)
+              [truncated]
+        """
+
+    it "should automatically limit number of lines when none are ours", ->
+        dummyException = """
+            Error: foo
+              at Interface.<anonymous> (/Users/jwalton/.nvm/v0.10.32/lib/node_modules/coffee-script/lib/coffee-script/repl.js:66:9)
+              at bar (/Users/jwalton/project/node_modules/express/x/y.js:21:4)
+              at foo (/Users/jwalton/project/src/x/y.coffee:188:19)
+              at ReadStream.Readable.push (_stream_readable.js:127:10)
+              at TTY.onread (net.js:528:21)
+        """
+        result = exceptionFormatter dummyException, {format: "ascii", maxLines: 'auto', basepath: '/Users/bob/project/', basepathReplacement: './'}
+        expect(result).to.equal """
+            Error: foo
+              at Interface.<anonymous> (/Users/jwalton/.nvm/v0.10.32/lib/node_modules/coffee-script/lib/coffee-script/repl.js:66:9)
+              at bar (/Users/jwalton/project/node_modules/express/x/y.js:21:4)
+              at foo (/Users/jwalton/project/src/x/y.coffee:188:19)
+              at ReadStream.Readable.push (_stream_readable.js:127:10)
+              at TTY.onread (net.js:528:21)
+        """


### PR DESCRIPTION
There was an undefined access when using maxLines, fixed and added a test for it.

Also added an option `maxLines: "auto"` which automatically finds and truncates at the last owned line, which is commonly what you want when dealing with long stack traces from async code.
