### PR TITLE
Add MIT license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "exception-formatter",
   "version": "1.0.7",
   "author": "Jason Walton <dev@lucid.thedreaming.org> (https://github.com/jwalton)",
+  "license": "MIT",
   "keywords": [
     "error",
     "exception",


### PR DESCRIPTION
https://www.npmjs.com/package/exception-formatter shows the project as having no license, which is inaccurate. This patch corrects that issue.